### PR TITLE
Implement Drop trait for Context and Device

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -9,5 +9,4 @@ fn main(){
     println!("OHMD_ROTATION_QUAT {:?}", device.getf(ohmd_float_value::OHMD_ROTATION_QUAT));
     println!("OHMD_SCREEN_HORIZONTAL_RESOLUTION {:?}", device.geti(ohmd_int_value::OHMD_SCREEN_HORIZONTAL_RESOLUTION));
     println!("OHMD_SCREEN_VERTICAL_RESOLUTION {:?}", device.geti(ohmd_int_value::OHMD_SCREEN_VERTICAL_RESOLUTION));
-    context.destroy();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,3 +73,11 @@ impl Device{
         out[0]
     }
 }
+
+impl Drop for Device{
+    fn drop(&mut self){
+        unsafe{
+            ohmd_close_device(self.device);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,12 +21,6 @@ impl Context{
         }
     }
 
-    pub fn destroy(&self){
-        unsafe{
-            ohmd_ctx_destroy(self.context);
-        }
-    }
-
     pub fn probe(&self) -> i32{
         unsafe{
             ohmd_ctx_probe(self.context) as i32
@@ -50,6 +44,14 @@ impl Context{
     pub fn get_error(&self) -> i32{
         unsafe{
             ohmd_ctx_get_error(self.context) as i32
+        }
+    }
+}
+
+impl Drop for Context{
+    fn drop(&mut self){
+        unsafe{
+            ohmd_ctx_destroy(self.context);
         }
     }
 }


### PR DESCRIPTION
With this change, the context can be destroyed via context.drop(), and devices can be closed via device.drop(). It happens automatically if they go out of scope.